### PR TITLE
Extract comment view markup into partials

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -18,34 +18,10 @@
 </p>
 
 <h2>Comments</h2>
-<% @article.comments.each do |comment| %>
-  <p>
-    <strong>Commenter:</strong>
-    <%= comment.commenter %>
-  </p>
-
-  <p>
-    <strong>Comment:</strong>
-    <%= comment.body %>
-  </p>
-<% end %>
+<%= render @article.comments %>
 
 <h2>Add a comment:</h2>
-<%= form_with(model: [ @article, @article.comments.build ], local: true) do |form|%>
-  <p>
-    <%= form.label :commenter %><br />
-    <%= form.text_field :commenter %>
-  </p>
-  <p>
-    <%= form.label :body %><br />
-    <%= form.text_field :body %>
-  </p>
-  <p>
-    <%= form.submit %>
-  </p>
-  <% end %>
-
-
+<%= render 'comments/form' %>
 
 <%= link_to 'Edit', edit_article_path(@article) %> |
 <%= link_to 'Back', articles_path%>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,0 +1,9 @@
+  <p>
+    <strong>Commenter:</strong>
+    <%= comment.commenter %>
+  </p>
+
+  <p>
+    <strong>Comment:</strong>
+    <%= comment.body %>
+  </p>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,0 +1,13 @@
+<%= form_with(model: [ @article, @article.comments.build ], local: true) do |form|%>
+  <p>
+    <%= form.label :commenter %><br />
+    <%= form.text_field :commenter %>
+  </p>
+  <p>
+    <%= form.label :body %><br />
+    <%= form.text_field :body %>
+  </p>
+  <p>
+    <%= form.submit %>
+  </p>
+  <% end %>


### PR DESCRIPTION
Clean up the article rendering markup by extracting the markup for
comments into partials. Again, we're just following along with the
Rails Guides here.